### PR TITLE
Cleanup event

### DIFF
--- a/events/event.storage_action.php
+++ b/events/event.storage_action.php
@@ -85,6 +85,7 @@
             $result = new XMLElement($this->ROOTELEMENT);
             $result->setAttribute('type', $action);
 
+            $errors = $storage->getErrors();
             if(!empty($errors)) {
                 $result->setAttribute('result', 'error');
                 foreach($errors as $error) {


### PR DESCRIPTION
There is no need to put half of the execution code in a separate function, so I copied it into the `__trigger()` function. The function name was wrong anyway (because the event was actually executed before). I also removed some coments, which actually makes the code simpler to read in this case.
