### PR TITLE
Add data-context to show options in symphony 2.6.x

### DIFF
--- a/data-sources/datasource.storage.php
+++ b/data-sources/datasource.storage.php
@@ -55,6 +55,7 @@
 
             $fieldset = new XMLElement('fieldset');
             $fieldset->setAttribute('class', 'settings contextual ' . __CLASS__);
+            $fieldset->setAttribute('data-context', 'storage');
             $fieldset->appendChild(new XMLElement('legend', self::getName()));
 
             // Groups

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -14,6 +14,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.5.1" date="2015-11-23" min="2.3">
+			- Bug fix, add attribute data-context to display options in symphony 2.6.x
+		</release>
 		<release version="1.5.0" date="2013-05-27" min="2.3">
 			- Refactored storage class; storage can actually be unset now, fixes cookie issues.
 		</release>


### PR DESCRIPTION
The datasource options got the class ```irrelevant``` due to missing attribute data-context