### PR TITLE
Datasource: "Filter by Groups" clickable again

### DIFF
--- a/data-sources/datasource.storage.php
+++ b/data-sources/datasource.storage.php
@@ -76,7 +76,7 @@ class StorageDatasource extends DataSource implements iDatasource
         $groups = $storage->getGroups();
 
         if (!empty($groups)) {
-            $tags = new XMLElement('ul', null, array('class' => 'tags'));
+            $tags = new XMLElement('ul', null, array('class' => 'tags', 'data-interactive' => 'data-interactive'));
             foreach ($groups as $group) {
                 $tags->appendChild(new XMLElement('li', $group));
             }


### PR DESCRIPTION
The "Suggest existing groups" feature listed existing groups but clicking those entries did not add them to the filter.